### PR TITLE
Use config boundaries instead of hardcoded

### DIFF
--- a/configs/ljs_base.json
+++ b/configs/ljs_base.json
@@ -20,6 +20,7 @@
     "training_files":"filelists/ljs_audio_text_train_filelist.txt.cleaned",
     "validation_files":"filelists/ljs_audio_text_val_filelist.txt.cleaned",
     "text_cleaners":["english_cleaners2"],
+    "audio_boundaries": [32,300,400,500,600,700,800,900,1000],
     "max_wav_value": 32768.0,
     "sampling_rate": 22050,
     "filter_length": 1024,

--- a/configs/ljs_nosdp.json
+++ b/configs/ljs_nosdp.json
@@ -21,6 +21,7 @@
     "validation_files":"filelists/ljs_audio_text_val_filelist.txt.cleaned",
     "text_cleaners":["english_cleaners2"],
     "max_wav_value": 32768.0,
+    "audio_boundaries": [32,300,400,500,600,700,800,900,1000],
     "sampling_rate": 22050,
     "filter_length": 1024,
     "hop_length": 256,

--- a/configs/vctk_base.json
+++ b/configs/vctk_base.json
@@ -21,6 +21,7 @@
     "validation_files":"filelists/vctk_audio_sid_text_val_filelist.txt.cleaned",
     "text_cleaners":["english_cleaners2"],
     "max_wav_value": 32768.0,
+    "audio_boundaries": [32,300,400,500,600,700,800,900,1000],
     "sampling_rate": 22050,
     "filter_length": 1024,
     "hop_length": 256,

--- a/train.py
+++ b/train.py
@@ -67,7 +67,7 @@ def run(rank, n_gpus, hps):
   train_sampler = DistributedBucketSampler(
       train_dataset,
       hps.train.batch_size,
-      [32,300,400,500,600,700,800,900,1000],
+      hps.data.audio_boundaries,
       num_replicas=n_gpus,
       rank=rank,
       shuffle=True)

--- a/train_ms.py
+++ b/train_ms.py
@@ -67,7 +67,7 @@ def run(rank, n_gpus, hps):
   train_sampler = DistributedBucketSampler(
       train_dataset,
       hps.train.batch_size,
-      [32,300,400,500,600,700,800,900,1000],
+      hps.data.audio_boundaries,
       num_replicas=n_gpus,
       rank=rank,
       shuffle=True)


### PR DESCRIPTION
Some audios can be treated as too long by wav size and be removed from boundaries group.
Move their definitions in config files to make it possible to change them without editing code.